### PR TITLE
Fix SEGFAULT when canceling update

### DIFF
--- a/src/updates.cpp
+++ b/src/updates.cpp
@@ -461,7 +461,8 @@ void Updates::cancel()
 {
 	updateState = usWaiting;
 	cancelled = true;
-	http->cancel();
+	// maybe the http object is already destroyed.
+	if(http) http->cancel();
 }
 
 Update* Updates::getUpdateItem(const int index)


### PR DESCRIPTION
When the update window is closed with cancel
there is a SEGFAULT because it tries to cancel the
HTTP request which might not be initialized if the
update has not been started yet.
So just check if the HTTP object is not NULL.
