### PR TITLE
Fix spelling mistakes

### DIFF
--- a/resources/changelog.txt
+++ b/resources/changelog.txt
@@ -214,7 +214,7 @@ Windows Vista/7:
 2.3.3:
 ------
 
-- Added "No results found" message for searchs with no results
+- Added "No results found" message for searches with no results
 - Added the time remaining for videos with "no-size" (RTMP protocol)
 
 - Improved time remaining calculation (RTMP and HTTP protocols)
@@ -528,7 +528,7 @@ Windows:
 Windows (Static versions only):
 -------------------------------
 
-- Compiled with VC++ 9.0.2x version instead of VC++ 9.0.3x (wich caused alot of "This application has failed to start because the application configuration is incorrect. Reinstalling the application may fix this problem." messages.
+- Compiled with VC++ 9.0.2x version instead of VC++ 9.0.3x (wich caused a lot of "This application has failed to start because the application configuration is incorrect. Reinstalling the application may fix this problem." messages.
 
 2.0.0a:
 -------

--- a/resources/services/atom/atom.js
+++ b/resources/services/atom/atom.js
@@ -55,7 +55,7 @@ function getVideoInformation(url)
 	// download flv xml
 	var xml = http.downloadWebpage(xmlUrl);
 	var item = "";
-	// get flv url (get the max bitrate avaiable)
+	// get flv url (get the max bitrate available)
 	if (xml.toString().indexOf('bitrate="1000"') != -1)
 		item = copyBetween(xml, 'bitrate="1000"', '</src>');
 	else if (xml.toString().indexOf('bitrate="700"') != -1)

--- a/resources/translations/template_for_new_translations.ts
+++ b/resources/translations/template_for_new_translations.ts
@@ -2873,7 +2873,7 @@ font-size:12px;
     </message>
     <message>
         <location filename="../../ui/options.ui" line="1796"/>
-        <source>Adress:</source>
+        <source>Address:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2895,12 +2895,12 @@ font-size:12px;
     <message>
         <location filename="../../ui/options.ui" line="1854"/>
         <location filename="../../ui/options.ui" line="1860"/>
-        <source>Adress of your proxy configuration</source>
+        <source>Address of your proxy configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../ui/options.ui" line="1857"/>
-        <source>Proxy adress</source>
+        <source>Proxy address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3539,7 +3539,7 @@ font-size:12px;
     </message>
     <message>
         <location filename="../../src/forms/searchvideositemimpl.cpp" line="95"/>
-        <source>Download not avaiable...</source>
+        <source>Download not available...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/forms/optionsimpl.cpp
+++ b/src/forms/optionsimpl.cpp
@@ -346,7 +346,7 @@ void OptionsImpl::setInitialOptionsValues()
 	gpbProxy->setChecked(programOptions->getUseProxy());
 	edtUserName->setText(programOptions->getProxyUserName());
 	edtPassword->setText(programOptions->getProxyPassword());
-	edtAdress->setText(programOptions->getProxyAdress());
+	edtAddress->setText(programOptions->getProxyAddress());
 	spinBoxPort->setValue(programOptions->getProxyPort());
 
 	if (programOptions->getProxyType() != QNetworkProxy::HttpProxy &&
@@ -408,7 +408,7 @@ void OptionsImpl::setOptionsValues()
 	programOptions->setUseProxy(gpbProxy->isChecked());
 	programOptions->setProxyUserName(edtUserName->text());
 	programOptions->setProxyPassword(edtPassword->text());
-	programOptions->setProxyAdress(edtAdress->text());
+	programOptions->setProxyAddress(edtAddress->text());
 	programOptions->setProxyPort(spinBoxPort->value());
 	programOptions->setProxyType(cmbProxyType->currentIndex());
 

--- a/src/forms/searchvideositemimpl.cpp
+++ b/src/forms/searchvideositemimpl.cpp
@@ -89,10 +89,10 @@ void SearchVideosItemImpl::setSearchVideosItem(SearchResultItem *searchItem)
 
 	if (canBeDownloaded)
 		lblDownloadVideo->setText(QString("<a href=\"%1\"><img src=\":/buttons/images/film_add.png\" /></a>").arg(searchItem->getVideoUrl()));
-	else // download not avaiable
+	else // download not available
 	{
 		lblDownloadVideo->setText("<a href=\"%1\"><img src=\":/services/images/services/invalid.png\" /></a>");
-		lblDownloadVideo->setToolTip(tr("Download not avaiable..."));
+		lblDownloadVideo->setToolTip(tr("Download not available..."));
 	}
 }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -148,7 +148,7 @@ void ProgramOptions::load()
 
 	systemProxyConfiguration = settings.value("configuration/systemProxyConfiguration", systemProxyConfiguration).toBool();
 	useProxy = settings.value("configuration/useProxy", useProxy).toBool();
-	proxyAdress = settings.value("configuration/proxyAdress", proxyAdress).toString();
+	proxyAddress = settings.value("configuration/proxyAddress", proxyAddress).toString();
 	proxyPassword = settings.value("configuration/proxyPassword", proxyPassword).toString();
 	proxyUserName = settings.value("configuration/proxyUserName", proxyUserName).toString();
 	proxyPort = settings.value("configuration/proxyPort", proxyPort).toInt();
@@ -232,7 +232,7 @@ void ProgramOptions::save()
 
 	settings.setValue("systemProxyConfiguration", systemProxyConfiguration);
 	settings.setValue("useProxy", useProxy);
-	settings.setValue("proxyAdress", proxyAdress);
+	settings.setValue("proxyAddress", proxyAddress);
 	settings.setValue("proxyPassword", proxyPassword);
 	settings.setValue("proxyUserName", proxyUserName);
 	settings.setValue("proxyPort", proxyPort);
@@ -336,7 +336,7 @@ void ProgramOptions::setDefault()
 
 	systemProxyConfiguration = true;
 	useProxy = false;
-	proxyAdress = "";
+	proxyAddress = "";
 	proxyPassword = "";
 	proxyUserName = "";
 	proxyPort = 0;
@@ -637,14 +637,14 @@ void ProgramOptions::setProxyPassword(QString value)
 	proxyPassword = value;
 }
 
-QString ProgramOptions::getProxyAdress()
+QString ProgramOptions::getProxyAddress()
 {
-	return proxyAdress;
+	return proxyAddress;
 }
 
-void ProgramOptions::setProxyAdress(QString value)
+void ProgramOptions::setProxyAddress(QString value)
 {
-	proxyAdress = value;
+	proxyAddress = value;
 }
 
 int ProgramOptions::getProxyPort()

--- a/src/options.h
+++ b/src/options.h
@@ -64,7 +64,7 @@ Q_OBJECT
 		int maxActiveDownloads;			//!< Maximum active downloads
 		bool systemProxyConfiguration;	//!< flag for know if Proxy is automatic (using system-configuration)
 		bool useProxy;					//!< flag for know if Proxy is enabled or not
-		QString proxyAdress;			//!< Proxy Adress
+		QString proxyAddress;			//!< Proxy Address
 		QString proxyPassword;			//!< Proxy Password
 		QString proxyUserName;			//!< Proxy UserName
 		int proxyPort;					//!< Proxy Port
@@ -168,8 +168,8 @@ Q_OBJECT
 		int getMaxActiveDownloads();
 		void setProxyPort(int value);
 		int getProxyPort();
-		void setProxyAdress(QString value);
-		QString getProxyAdress();
+		void setProxyAddress(QString value);
+		QString getProxyAddress();
 		void setProxyPassword(QString value);
 		QString getProxyPassword();
 		void setProxyUserName(QString value);

--- a/src/searchvideos.h
+++ b/src/searchvideos.h
@@ -113,7 +113,7 @@ Q_OBJECT
 		void removeAllSearchResults();
 };
 
-/*! Download the video previews from searchs */
+/*! Download the video previews from searches */
 class SearchResultsPreviewCatcher : public QObject
 {
 Q_OBJECT
@@ -206,7 +206,7 @@ Q_OBJECT
 	signals:
 		/*! New search started */
 		void searchStarted();
-		/*! Added new search (used on multiple searchs) */
+		/*! Added new search (used on multiple searches) */
 		void addNewSearchBlock(VideoInformationPlugin *plugin);
 		/*! The current search finished */
 		void searchFinished();

--- a/src/videolistcontroller.cpp
+++ b/src/videolistcontroller.cpp
@@ -688,7 +688,7 @@ void VideoListController::setupProxy()
 			QNetworkProxy networkProxy;
 			networkProxy.setUser(programOptions->getProxyUserName());
 			networkProxy.setPassword(programOptions->getProxyPassword());
-			networkProxy.setHostName(programOptions->getProxyAdress());
+			networkProxy.setHostName(programOptions->getProxyAddress());
 			networkProxy.setPort(programOptions->getProxyPort());
 			networkProxy.setType(static_cast<QNetworkProxy::ProxyType>(programOptions->getProxyType()));
 			// set application proxy

--- a/tools/DebugPlugins/src/forms/mainwindow.cpp
+++ b/tools/DebugPlugins/src/forms/mainwindow.cpp
@@ -130,7 +130,7 @@ void MainWindow::testPluginSearchVideos(bool debug)
 	ui->outputSearchVideos->appendHtml(QString("<b>Loaded:</b> %1").arg(plugin.isLoaded() ? "Yes" : "No"));
 	ui->outputSearchVideos->appendHtml("</p>");
 
-	// searchs information
+	// searches information
 
 	ui->outputSearchVideos->appendHtml("<u><font size='+1'>Search information:</font></u>");
 	ui->outputSearchVideos->appendHtml("<p>");
@@ -138,7 +138,7 @@ void MainWindow::testPluginSearchVideos(bool debug)
 	ui->outputSearchVideos->appendHtml(QString("<b>Results count:</b> %1").arg(sr.getSearchResultCount()));
 	ui->outputSearchVideos->appendHtml("</p>");
 
-	// searchs results
+	// searches results
 
 	ui->outputSearchVideos->appendHtml("<u><font size='+1'>Search results:</font></u>");
 	ui->outputSearchVideos->appendHtml("<p>");

--- a/tools/MigrationTool/Windows/1_8_2a-to-2_0a/src/MainForm.dfm
+++ b/tools/MigrationTool/Windows/1_8_2a-to-2_0a/src/MainForm.dfm
@@ -2265,7 +2265,7 @@ object frmMain: TfrmMain
     Height = 39
     AutoSize = False
     Caption = 
-      'The new version of xVST comes with alot of new features, all web' +
+      'The new version of xVST comes with a lot of new features, all web' +
       'services has been updated, an updated video converter (ffmpeg 0.' +
       '5), etc... You can read the full changelog clicking the "xVST 2.' +
       '0 changelog" button.'

--- a/ui/options.ui
+++ b/ui/options.ui
@@ -1791,9 +1791,9 @@
                 </widget>
                </item>
                <item row="2" column="0" colspan="2">
-                <widget class="QLabel" name="lblAdress">
+                <widget class="QLabel" name="lblAddress">
                  <property name="text">
-                  <string>Adress:</string>
+                  <string>Address:</string>
                  </property>
                 </widget>
                </item>
@@ -1843,7 +1843,7 @@
                 </layout>
                </item>
                <item row="3" column="0" colspan="3">
-                <widget class="QLineEdit" name="edtAdress">
+                <widget class="QLineEdit" name="edtAddress">
                  <property name="minimumSize">
                   <size>
                    <width>0</width>
@@ -1851,13 +1851,13 @@
                   </size>
                  </property>
                  <property name="whatsThis">
-                  <string>Adress of your proxy configuration</string>
+                  <string>Address of your proxy configuration</string>
                  </property>
                  <property name="accessibleName">
-                  <string>Proxy adress</string>
+                  <string>Proxy address</string>
                  </property>
                  <property name="accessibleDescription">
-                  <string>Adress of your proxy configuration</string>
+                  <string>Address of your proxy configuration</string>
                  </property>
                 </widget>
                </item>


### PR DESCRIPTION
Those spelling mistakes were found by Debian's lintian
in the executable xvst.
Probably the translations also need to be regenerated.
Some of the fixes affect member names or names of GUI elements.
