### PR TITLE
qtlocalpeer.cpp: getuid compilation fix

### DIFF
--- a/src/qtsingleapplication/src/qtlocalpeer.cpp
+++ b/src/qtsingleapplication/src/qtlocalpeer.cpp
@@ -93,7 +93,7 @@ QtLocalPeer::QtLocalPeer(QObject* parent, const QString &appId)
         socketName += QLatin1Char('-') + QString::number(sessionId, 16);
     }
 #else
-    socketName += QLatin1Char('-') + QString::number(::getuid(), 16);
+    socketName += QLatin1Char('-') + QString::number(QtLP_Private::getuid(), 16);
 #endif
 
     server = new QLocalServer(this);


### PR DESCRIPTION
The compilation failed because the getuid method is not
in the current class but in QtLP_Private.
Change the namespace accordingly.
