### PR TITLE
Add missing QDataStream include to qtlocalpeer.cpp

### DIFF
--- a/src/qtsingleapplication/src/qtlocalpeer.cpp
+++ b/src/qtsingleapplication/src/qtlocalpeer.cpp
@@ -41,6 +41,7 @@
 #include "qtlocalpeer.h"
 #include <QCoreApplication>
 #include <QTime>
+#include <QDataStream>
 
 #if defined(Q_OS_WIN)
 #include <QLibrary>


### PR DESCRIPTION
``` plain
g++ -c -pipe -O2 -march=x86-64 -mtune=generic -O2 -pipe -fstack-protector-strong -Wall -W -D_REENTRANT -fPIC -DxVST_DEBUG_PLUGINS_OFF -DQT_NO_DEBUG -DQT_WEBKITWIDGETS_LIB -DQT_WIDGETS_LIB -DQT_WEBKIT_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_SCRIPT_LIB -DQT_CORE_LIB -I. -Isrc/qtsingleapplication/src -isystem /usr/include/qt -isystem /usr/include/qt/QtWebKitWidgets -isystem /usr/include/qt/QtWidgets -isystem /usr/include/qt/QtWebKit -isystem /usr/include/qt/QtGui -isystem /usr/include/qt/QtNetwork -isystem /usr/include/qt/QtScript -isystem /usr/include/qt/QtCore -Ibuild/moc -Ibuild/ui -I/usr/lib/qt/mkspecs/linux-g++ -o build/o/unix/qtlocalpeer.o src/qtsingleapplication/src/qtlocalpeer.cpp
src/qtsingleapplication/src/qtlocalpeer.cpp: In member function ‘bool QtLocalPeer::sendMessage(const QString&, int)’:
src/qtsingleapplication/src/qtlocalpeer.cpp:159:19: error: variable ‘QDataStream ds’ has initializer but incomplete type
     QDataStream ds(&socket);
                   ^
src/qtsingleapplication/src/qtlocalpeer.cpp: In member function ‘void QtLocalPeer::receiveConnection()’:
src/qtsingleapplication/src/qtlocalpeer.cpp:179:26: error: variable ‘QDataStream ds’ has initializer but incomplete type
     QDataStream ds(socket);
                          ^
make[1]: *** [Makefile.Release:1316: build/o/unix/qtlocalpeer.o] Error 1
make[1]: Leaving directory '/home/marcin/Downloads/github/xVideoServiceThief'
make: *** [Makefile:38: release] Error 2

```
